### PR TITLE
No visible cursor on GraphQL Playground fixed

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -36,7 +36,12 @@ const typeDefs = gql`
 
 const server = new ApolloServer({
   typeDefs,
-  resolvers
+  resolvers,
+  playground: {
+    settings: {
+      'editor.cursorShape': 'line'
+    }
+  }
 });
 
 server.listen().then(({ url }) => {


### PR DESCRIPTION
When making mutation on GraphQL Playground, then it's tough to work with because the cursor is not visible. So I fixed it now by changing the Playground Settings. Now it's working :smiley_cat: